### PR TITLE
fix(cap3): agrega TikTok como cuarta fuente en Analisis de los datos

### DIFF
--- a/3/figures/flujo_tiktok_posts.tex
+++ b/3/figures/flujo_tiktok_posts.tex
@@ -1,0 +1,24 @@
+% Fig 4:fig6b -- Proceso de recoleccion del corpus de TikTok
+\begin{tikzpicture}[
+    node distance=0.6cm,
+    every node/.style={font=\footnotesize, align=center, inner sep=4pt},
+    src/.style={draw, rounded corners=2pt, fill=red!12, minimum width=4.6cm, minimum height=0.9cm},
+    config/.style={draw, rounded corners=2pt, fill=blue!12, minimum width=4.6cm, minimum height=0.9cm},
+    proc/.style={draw, rounded corners=2pt, fill=yellow!15, minimum width=4.6cm, minimum height=0.9cm},
+    filter/.style={draw, dashed, rounded corners=2pt, fill=orange!15, minimum width=4.6cm, minimum height=0.8cm, font=\scriptsize},
+    storage/.style={draw, rounded corners=2pt, fill=brown!20, minimum width=4.6cm, minimum height=1cm, font=\footnotesize\bfseries},
+    arrow/.style={-{Stealth[length=2mm]}, thick}
+]
+    \node[src] (s1) {Identificacion de cuentas y rango de fechas\\\scriptsize ACCOUNTS, DATE\_FROM, DATE\_TO};
+    \node[config, below=of s1] (s2) {Playwright sobre Chromium\\\scriptsize scraper-tiktok (arquitectura hexagonal)};
+    \node[proc, below=of s2] (s3) {Recorrido de playlist\\\scriptsize ordenadas de mas reciente a mas antiguo};
+    \node[filter, below=of s3] (s4) {Parada temprana (match\_filter)\\post-filtro estricto por rango de fechas};
+    \node[proc, below=of s4] (s5) {Extraccion de descripcion, hashtags\\y metadatos por post};
+    \node[storage, below=of s5] (s6) {Capa Bronze\\\scriptsize data/raw/tiktok/\{YYYY-MM-DD\}/};
+
+    \draw[arrow] (s1) -- (s2);
+    \draw[arrow] (s2) -- (s3);
+    \draw[arrow] (s3) -- (s4);
+    \draw[arrow] (s4) -- (s5);
+    \draw[arrow] (s5) -- (s6);
+\end{tikzpicture}

--- a/3/metodologia.tex
+++ b/3/metodologia.tex
@@ -393,6 +393,14 @@ Construir corpus de YouTube.
 \item Almacenar transcripciones crudas en capa Bronze.
 \end{itemize} \\
 \hline
+Construir corpus de TikTok.
+& Construcción del corpus de posts electorales de TikTok mediante scraper independiente.
+& \begin{itemize}[label={--},nosep,leftmargin=*]
+\item Identificar cuentas y rangos de fechas objetivo de cobertura electoral.
+\item Recolectar posts con descripción, hashtags y metadatos vía Playwright.
+\item Almacenar posts crudos en capa Bronze.
+\end{itemize} \\
+\hline
 Realizar análisis exploratorio del corpus.
 & Análisis estadístico y exploratorio de las variables del corpus para cada fuente de datos.
 & \begin{itemize}[label={--},nosep,leftmargin=*]
@@ -451,11 +459,26 @@ La recolección de contenido de YouTube se realizó mediante \texttt{yt-dlp}, un
 \end{figure}
  
 \textbf{Entregable}: Corpus de transcripciones de videos de YouTube con ID de video, texto transcrito, fecha de publicación, canal, duración y flag de autogeneración.
- 
-\textbf{Actividad 4: Realizar análisis exploratorio del corpus}
- 
-En esta actividad se realizó el análisis estadístico descriptivo de los tres corpus recolectados: distribución temporal de publicaciones, longitud promedio de textos, distribución de menciones por candidato y por fuente, y análisis del vocabulario electoral dominante mediante nubes de palabras.
- 
+
+\textbf{Actividad 4: Construir corpus de TikTok}
+
+La recolección de contenido de TikTok se realizó mediante un scraper independiente (repositorio \texttt{scraper-tiktok}) implementado con \texttt{Playwright} sobre Chromium, bajo una arquitectura hexagonal de puertos y adaptadores. El scraper opera por cuenta y rango de fechas (\texttt{DATE\_FROM}/\texttt{DATE\_TO}), aprovechando que las playlists de TikTok están ordenadas de más reciente a más antiguo para aplicar dos capas de filtrado: una parada temprana basada en \texttt{match\_filter} y un post-filtro estricto sobre el rango de fechas que garantiza que solo posts dentro del período objetivo lleguen al almacenamiento. El módulo \texttt{TiktokIngestor} (\texttt{src/electoral/ingestion/tiktok.py}) consume los archivos JSON producidos por el scraper y los persiste como documentos en la capa Bronze del pipeline en \texttt{data/raw/tiktok/\{YYYY-MM-DD\}/}, con el mismo schema canónico que las demás fuentes.
+
+\begin{figure}[!ht]
+    \begin{center}
+        \resizebox{0.85\textwidth}{!}{\input{3/figures/flujo_tiktok_posts.tex}}
+        \caption[Proceso de recolección del corpus de TikTok mediante scraper Playwright]{Proceso de extracción de posts electorales de TikTok mediante \texttt{Playwright} y arquitectura hexagonal, desde la configuración de cuentas y rango de fechas hasta el almacenamiento en capa Bronze.\\
+            Fuente: Elaboración propia.}
+        \label{4:fig6b}
+    \end{center}
+\end{figure}
+
+\textbf{Entregable}: Corpus de posts de TikTok con ID, descripción, hashtags, fecha de publicación, cuenta de origen y métricas de interacción.
+
+\textbf{Actividad 5: Realizar análisis exploratorio del corpus}
+
+En esta actividad se realizó el análisis estadístico descriptivo de los cuatro corpus recolectados: distribución temporal de publicaciones, longitud promedio de textos, distribución de menciones por candidato y por fuente, y análisis del vocabulario electoral dominante mediante nubes de palabras.
+
 \textbf{Entregable}: Gráficos estadísticos y descriptivos del corpus por fuente de datos.
  
 \subsubsection{Preparación de la información}
@@ -510,7 +533,7 @@ actividades de esta etapa se detallan en la Tabla \ref{4:table5}.
  
 \textbf{Actividad 1: Limpiar y normalizar el corpus}
  
-En esta actividad se aplicó un pipeline de preprocesamiento textual sobre los tres corpus de la capa Bronze. El proceso incluyó la eliminación de spam y cuentas de bots identificadas mediante patrones de comportamiento, la normalización de emojis (convertidos a texto descriptivo), la eliminación de URLs y menciones de usuario, y la detección automática de idioma mediante la librería \texttt{langdetect} para conservar únicamente publicaciones en español.
+En esta actividad se aplicó un pipeline de preprocesamiento textual sobre los cuatro corpus de la capa Bronze. El proceso incluyó la eliminación de spam y cuentas de bots identificadas mediante patrones de comportamiento, la normalización de emojis (convertidos a texto descriptivo), la eliminación de URLs y menciones de usuario, y la detección automática de idioma mediante la librería \texttt{langdetect} para conservar únicamente publicaciones en español.
  
 \textbf{Entregable}: Corpus limpio y normalizado, listo para análisis con LLM.
  


### PR DESCRIPTION
La seccion "Analisis de los datos" del cap 3 (metodologia) tenia solo 3 actividades de construccion de corpus (noticias, X/Twitter, YouTube), omitiendo TikTok que ya esta integrado en el pipeline real del repo electoral-intelligence (TiktokIngestor en src/electoral/ ingestion/tiktok.py + repo dedicado scraper-tiktok con Playwright).

Cambios:

3/metodologia.tex - Tabla 4:table4 (plan de ejecucion):
- Se agrega fila "Construir corpus de TikTok" con su alcance (corpus de posts electorales con Playwright) y acciones (identificacion de cuentas, recoleccion via Playwright, almacenamiento en capa Bronze).

3/metodologia.tex - Actividades textuales:
- Nueva Actividad 4: "Construir corpus de TikTok" con descripcion detallada del scraper (Playwright sobre Chromium, arquitectura hexagonal, parada temprana, post-filtro por fechas), su modulo TiktokIngestor y persistencia en data/raw/tiktok/{fecha}/.
- La antigua Actividad 4 (analisis exploratorio) se renumera a Actividad 5 y se actualiza "tres corpus" -> "cuatro corpus".

3/metodologia.tex - Actividad 1 de Preparacion (L536):
- "tres corpus de la capa Bronze" -> "cuatro corpus" (incluye TikTok en el preprocesamiento textual).

3/figures/flujo_tiktok_posts.tex (nuevo archivo):
- Diagrama TikZ del flujo de recoleccion de TikTok que sigue el mismo estilo que los flujos de noticias, twitter y youtube existentes en 3/figures/.

Verificacion: actividades 1-5 presentes en la seccion, balance de llaves intacto, las menciones existentes en otras secciones del cap 3 (L18, L22, L93, L260) ya estaban correctamente alineadas a las cuatro fuentes.